### PR TITLE
Clarified a couple things.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,16 @@ The **McfHash** class is a PHP implementation of [Binary Modular Crypt Format][b
 [bmcf]:         https://github.com/ademarre/binary-mcf "Binary Modular Crypt Format"
 [bcryptbmcf]:   https://github.com/ademarre/binary-mcf#bcrypt-bmcf-definition "Bcrypt BMCF Definition"
 
-You can use <code>McfHash::decode()</code> to convert a Bcrypt hash from the usual 60-character notation to its compact 40-byte binary form.
+You can use the <code>decode()</code> function to convert a Bcrypt hash from the usual 60-character notation to its compact 40-byte binary form.
 
 ```php
-$hash = '$2y$14$i5btSOiulHhaPHPbgNUGdObga/GC.AVG/y5HHY1ra7L0C9dpCaw8u'; // 60 bytes ACSII
+$hash = '$2y$14$i5btSOiulHhaPHPbgNUGdObga/GC.AVG/y5HHY1ra7L0C9dpCaw8u'; // $hash is 60 bytes ACSII.
 $mcfEncoder = new McfHash();
-$binaryHash = $mcfEncoder->decode($hash); // 40 bytes binary
+$binaryHash = $mcfEncoder->decode($hash); // $binaryHash is now 40 bytes binary.
 ```
 
-Use <code>McfHash::encode()</code> to reconstruct the hash.
+Use the <code>encode()</code> function to reconstruct the hash.
 
 ```php
-$hash = $mcfEncoder->encode($binaryHash);
-// $2y$14$i5btSOiulHhaPHPbgNUGdObga/GC.AVG/y5HHY1ra7L0C9dpCaw8u
+$binaryHash = $mcfEncoder->encode($binaryHash); // $binaryHash is now 60 bytes ACSII once again ($2y$14$i5btSOiulHhaPHPbgNUGdObga/GC.AVG/y5HHY1ra7L0C9dpCaw8u).
 ```


### PR DESCRIPTION
Changed from <code>McfHash::decode()</code>/<code>McfHash::encode()</code> to "<code>decode()</code> function"/"<code>encode()</code> function" to avoid confusion. Neither <code>decode()</code> nor <code>encode()</code> are static functions, therefore making this type of function call invalid.

Also added a couple extra comments to make the decoding and encoding process a little easier to understand.
